### PR TITLE
fix: support windows command promptr

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,6 @@ jobs:
           ${{ runner.os }}-
     - name: Install dependencies
       run: npm ci
-    - name: Lint commit messages
-      run: npm run commitlint
     - name: Lint
       run: npm run lint
     - name: Link

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,11 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v2

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -12,7 +12,7 @@ export const runAudit = (
   return new Promise((resolve, reject) => {
     let stderr = '';
 
-    const command = 'npm';
+    const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
     const command_args = ['audit', '--json'];
 
     if (options.npmExtraParams) {


### PR DESCRIPTION
# Brief description

* [ ] Feature request
* [x] Bug
* [ ] Docs



## What is fixed, What feature is added
I created this PR to support Windows command prompt too.

When I ran the tool on Windows platform, I got the following error:

```
> npx @supercharge/audit-ci-wrapper --config "auditconfig.json"

Reading config file.
events.js:291
      throw er; // Unhandled 'error' event
      ^

Error: spawn npm ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:268:19)
    at onErrorNT (internal/child_process.js:470:16)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
Emitted 'error' event on ChildProcess instance at:
    at Process.ChildProcess._handle.onexit (internal/child_process.js:274:12)
    at onErrorNT (internal/child_process.js:470:16)
    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  errno: 'ENOENT',
  code: 'ENOENT',
  syscall: 'spawn npm',
  path: 'npm',
  spawnargs: [ 'audit', '--json' ]
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! osn@0.0.1 audit: `npx @supercharge/audit-ci-wrapper --config "auditconfig.json"`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the osn@0.0.1 audit script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\Administrator\AppData\Roaming\npm-cache\_logs\2020-12-01T15_07_54_147Z-debug.log
```

My fix is based on the following stackoverflow conversation: https://stackoverflow.com/questions/43230346/error-spawn-npm-enoent

