### PR TITLE
fix: exit with code 1 on caught error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,4 +28,5 @@ const args = parseArgs();
 })().catch((err) => {
   console.error('Error happened!');
   console.dir(err);
+  process.exit(1);
 });


### PR DESCRIPTION
# Brief description

* [ ] Feature request
* [x] Bug
* [ ] Docs



## What is fixed, What feature is added

When npm audit throws an error, wrapper lib doesn't terminate the process, though it catches the exception.
